### PR TITLE
fix(report): prevent duplicate console report output

### DIFF
--- a/modelbrief/core/report.py
+++ b/modelbrief/core/report.py
@@ -85,7 +85,7 @@ class ModelBrief:
   except Exception as e: r.warnings.append(f"Visualisation skipped: {e}")
  def show(self):
   from ..output.console import render_console
-  text=render_console(self.analyse()); print(text); return text
+  return render_console(self.analyse())
  def html(self,path="modelbrief_report.html"):
   from ..output.html import render_html; return render_html(self.analyse(),path)
  def pdf(self,path="modelbrief_report.pdf"):

--- a/modelbrief/output/console.py
+++ b/modelbrief/output/console.py
@@ -1,9 +1,20 @@
 import json
+
+
+class ConsoleReport(str):
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
+
+
 def render_console(result):
- lines=["="*72,"MODELBRIEF REPORT","="*72]
- for s in result.sections:
-  lines += ["",s.title.upper(),"-"*len(s.title),json.dumps(s.content,indent=2,default=str)]
-  if s.narrative: lines.append(s.narrative)
- if result.warnings: lines += ["","WARNINGS",*['- '+x for x in result.warnings]]
- if result.recommendations: lines += ["","RECOMMENDATIONS",*['- '+x for x in result.recommendations]]
- return "\n".join(lines)
+    lines = ["=" * 72, "MODELBRIEF REPORT", "=" * 72]
+    for s in result.sections:
+        lines += ["", s.title.upper(), "-" * len(s.title), json.dumps(s.content, indent=2, default=str)]
+        if s.narrative:
+            lines.append(s.narrative)
+    if result.warnings:
+        lines += ["", "WARNINGS", *["- " + x for x in result.warnings]]
+    if result.recommendations:
+        lines += ["", "RECOMMENDATIONS", *["- " + x for x in result.recommendations]]
+    return ConsoleReport("\n".join(lines))
+

--- a/tests/unit/core/test_console_output.py
+++ b/tests/unit/core/test_console_output.py
@@ -1,0 +1,46 @@
+from modelbrief import ModelBrief
+from modelbrief.output.console import ConsoleReport
+
+
+class DummyEstimator:
+    _estimator_type = "classifier"
+
+    def predict(self, X):
+        return [0, 1][:len(X)]
+
+
+class DummyPrettyPrinter:
+    def __init__(self):
+        self.output = ""
+
+    def text(self, val):
+        self.output += val
+
+
+def test_show_does_not_print_internally(capsys):
+    report = ModelBrief(model=DummyEstimator(), X_test=[[1], [2]], y_test=[0, 1])
+    result = report.show()
+    captured = capsys.readouterr()
+
+    assert captured.out == ""
+    assert isinstance(result, str)
+    assert "MODELBRIEF REPORT" in result
+    assert "MODEL OVERVIEW" in result
+
+
+def test_print_show_outputs_report_exactly_once(capsys):
+    report = ModelBrief(model=DummyEstimator(), X_test=[[1], [2]], y_test=[0, 1])
+    print(report.show())
+    captured = capsys.readouterr()
+
+    assert captured.out.count("MODELBRIEF REPORT") == 1
+    assert captured.out.count("MODEL OVERVIEW") == 1
+
+
+def test_console_report_pretty_repr():
+    report_text = "MODELBRIEF REPORT\nTEST CONTENT"
+    console_report = ConsoleReport(report_text)
+    printer = DummyPrettyPrinter()
+    console_report._repr_pretty_(printer, cycle=False)
+
+    assert printer.output == report_text


### PR DESCRIPTION
## Summary

Calling print(report.show()) previously printed the complete report twice because show() executed an internal print call while also returning the rendered report string to the caller. This PR updates show() to return the rendered console report without the redundant internal print call, wraps console output in a ConsoleReport string helper supporting pretty printing in interactive environments, and adds unit tests to ensure console reports are only output once.

Closes #4

## Tests

- [x] `pytest` passes
- [x] Optional dependencies remain optional
- [x] No secrets or weights included
